### PR TITLE
Modify pluck behavior when seeing a `head` tag to include the `body`

### DIFF
--- a/lib/nokogiri/html5/inference.rb
+++ b/lib/nokogiri/html5/inference.rb
@@ -93,7 +93,7 @@ else
           TBODY = /\A\s*<(#{PluckTags::TBODY.join("|")})\b/i
           TBODY_TR = /\A\s*<(#{PluckTags::TBODY_TR.join("|")})\b/i
           COLGROUP = /\A\s*<(#{PluckTags::COLGROUP.join("|")})\b/i
-          HEAD_OUTER = /\A\s*<(head)\b/i
+          HTML_INNER = /\A\s*<(head)\b/i
           BODY_OUTER = /\A\s*<(body)\b/i
         end
 
@@ -184,7 +184,7 @@ else
             when PluckRegexp::TBODY then "tbody/*"
             when PluckRegexp::TBODY_TR then "tbody/tr/*"
             when PluckRegexp::COLGROUP then "colgroup/*"
-            when PluckRegexp::HEAD_OUTER then "head"
+            when PluckRegexp::HTML_INNER then "./*"
             when PluckRegexp::BODY_OUTER then "body"
             end
           end

--- a/test/nokogiri/html5/test_inference.rb
+++ b/test/nokogiri/html5/test_inference.rb
@@ -99,6 +99,25 @@ describe Nokogiri::HTML5::Inference do
       end
     end
 
+    describe "passed a Fragment containing head and body" do
+      it "returns a Fragment containing both head and body" do
+        fragment = "<head></head><body></body>"
+        actual = Nokogiri::HTML5::Inference.parse(fragment).to_html
+
+        assert_equal(fragment, actual)
+      end
+    end
+
+    describe "passed a Fragment containing head and p" do
+      it "returns a Fragment containing both head and body" do
+        fragment = "<head><p>"
+        expected = "<head></head><body><p></p></body>"
+        actual = Nokogiri::HTML5::Inference.parse(fragment).to_html
+
+        assert_equal(expected, actual)
+      end
+    end
+
     describe "multiple children that need plucking" do
       it "parses correctly" do
         fragment = "<tr><td>hello</td></tr><tr><td>world</td></tr>"

--- a/test/nokogiri/html5/test_inference.rb
+++ b/test/nokogiri/html5/test_inference.rb
@@ -26,7 +26,7 @@ describe Nokogiri::HTML5::Inference do
     ],
     "html" => [
       "<body><div>hello</div></body>",
-      "<head><meta charset=\"UTF-8\"><title>hello</title></head>"
+      "<head><meta charset=\"UTF-8\"><title>hello</title></head><body><div>hello</div></body>"
     ]
   }
 


### PR DESCRIPTION
Closes #3