### PR TITLE
use `template` as the context node

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ This result is _almost_ correct, but we're seeing another HTML5 parsing rule in 
 _intermediate parent tags_ that the HTML5 spec requires to be inserted by the parser. In this case,
 the `<td>` tag must be wrapped in `<tbody><tr>` tags.
 
-We can narrow down the result set with an XPath query to get back only the intended tags:
+We can fix this to only return the tags we provided by using the `<template>` tag as the context node, which the HTML5 spec provides exactly for this purpose:
 
 ``` ruby
 Nokogiri::HTML5::DocumentFragment.new(
   Nokogiri::HTML5::Document.new,
   "<td>foo</td>",
-  "table"  # this is the context node
-).xpath("tbody/tr/*").to_html
+  "template"  # <--- this is the context node
+).to_html
 # => "<td>foo</td>"
 ```
 

--- a/test/nokogiri/html5/test_inference.rb
+++ b/test/nokogiri/html5/test_inference.rb
@@ -4,15 +4,13 @@ require "test_helper"
 
 describe Nokogiri::HTML5::Inference do
   fragment_actions = {
-    "body" => [
+    "template" => [
       "<div>hello</div>",
       "<div class=\"big\">hello</div>",
       "<li>hello</li>",
       "<dl><dd>hello</dd><dt>world</dt></dl>",
       "<dd>hello</dd><dt>world</dt>",
-      "just some text"
-    ],
-    "table" => [
+      "just some text",
       "<thead><tr><td>hello</td></tr></thead>",
       "<tbody><tr><td>hello</td></tr></tbody>",
       "<tfoot><tr><td>hello</td></tr></tfoot>",
@@ -118,7 +116,7 @@ describe Nokogiri::HTML5::Inference do
       end
     end
 
-    describe "multiple children that need plucking" do
+    describe "multiple children" do
       it "parses correctly" do
         fragment = "<tr><td>hello</td></tr><tr><td>world</td></tr>"
         actual = Nokogiri::HTML5::Inference.parse(fragment).to_html
@@ -127,9 +125,9 @@ describe Nokogiri::HTML5::Inference do
       end
 
       describe "with pluck: false" do
-        it "includes the intermediate nodes created" do
-          fragment = "<tr><td>hello</td></tr><tr><td>world</td></tr>"
-          expected = "<tbody>#{fragment}</tbody>"
+        it "includes the additional sibling nodes created" do
+          fragment = "<body><div>hello</div></body>"
+          expected = "<head></head>#{fragment}"
           actual = Nokogiri::HTML5::Inference.parse(fragment, pluck: false).to_html
 
           assert_equal(expected, actual)


### PR DESCRIPTION
which simplifies the code quite a bit

Closes #2

cc @stevecheckoway
